### PR TITLE
Fix/diffing out of memory

### DIFF
--- a/src/generateIt.ts
+++ b/src/generateIt.ts
@@ -36,7 +36,7 @@ export default async (config: Config): Promise<boolean> => {
 
   if (!config.dontRunComparisonTool) {
     const diffObject = await GeneratedComparison.fileDiffs(config.targetDir);
-    await GeneratedComparison.fileDiffsPrint(config.targetDir, diffObject);
+    GeneratedComparison.fileDiffsPrint(config.targetDir, diffObject);
     GeneratedComparison.versionCleanup(config.targetDir);
   }
 

--- a/src/lib/FileIterator.ts
+++ b/src/lib/FileIterator.ts
@@ -66,7 +66,7 @@ class FileWalker {
         const jsFilename: string = `${ctx.dest}${path.sep}___eval.js`;
 
         if (ctx.src.endsWith('.ts')) {
-          const res = await typescript.transpileModule(fs.readFileSync(ctx.src, 'utf8'), {});
+          const res = typescript.transpileModule(fs.readFileSync(ctx.src, 'utf8'), {});
           fs.removeSync(path.join(ctx.dest, '___eval.ts'));
           fs.writeFileSync(jsFilename, res.outputText);
         }

--- a/src/lib/diff/fileDiff.ts
+++ b/src/lib/diff/fileDiff.ts
@@ -13,22 +13,21 @@ export default async (oldTextFile: string = '', newTextFile: string = ''): Promi
   let difference = '';
   let minus = 0;
   let plus = 0;
+
   m.on('-', (line: any, obj: any) => {
     ++minus;
-    const diffLine = `
-@line: ` + obj.lineNumber + `-
-` + line;
+    const diffLine = `\n@line: ${obj.lineNumber}-\n${line}`;
     difference += diffLine.red;
   });
 
   m.on('+', (line: any, obj: any) => {
     ++plus;
-    const diffLine = `
-@line: ` + obj.lineNumber + `+
-` + line;
+    const diffLine = `\n@line: ${obj.lineNumber}+\n${line}`;
     difference += diffLine.green;
   });
-  m.diff(oldTextFile, newTextFile);
+
+  await m.diff(oldTextFile, newTextFile);
+
   return {
     minus,
     plus,

--- a/src/lib/generate/GeneratedComparison.ts
+++ b/src/lib/generate/GeneratedComparison.ts
@@ -7,7 +7,6 @@ import fileDiff from '@/lib/diff/fileDiff';
 import { COMPARE_DIRECTORY, MAX_CACHE_COUNT } from '@/constants/CachePaths';
 
 class GeneratedComparison {
-
   public getCacheBaseDir (targetParentDirectory: string) {
     return path.join(targetParentDirectory, COMPARE_DIRECTORY);
   }
@@ -17,7 +16,7 @@ class GeneratedComparison {
    * @param {string} targetParentDirectory - The
    * @return {string}
    */
-  public getCacheCompareConfigPath (targetParentDirectory: string) {
+  public getCacheCompareConfigPath (targetParentDirectory: string): string {
     return path.join(this.getCacheBaseDir(targetParentDirectory), 'config.json');
   }
 
@@ -26,7 +25,7 @@ class GeneratedComparison {
    * @param jsonFilePath
    * @return {{versions: {}}}
    */
-  public getCacheCompareJson (jsonFilePath: string) {
+  public getCacheCompareJson (jsonFilePath: string): any {
     let json;
     if (fs.pathExistsSync(jsonFilePath)) {
       json = fs.readJsonSync(jsonFilePath);
@@ -54,39 +53,31 @@ class GeneratedComparison {
    * @param targetParentDirectory
    * @return {Promise<string|*>}
    */
-  public fileDiffs (targetParentDirectory: string): Promise<string> {
-    return new Promise((resolve, reject) => {
-      const json = this.getCacheCompareJson(this.getCacheCompareConfigPath(targetParentDirectory));
-      const versions = Object.keys(json.versions).sort();
-      if (versions.length <= 1) {
-        console.log('No previous files to compare from, a diff comparison chart will be available after the next generation.');
-        return resolve('');
-      }
-      const newVersionKey = versions.pop();
-      const oldVersionKey = versions.pop();
-      let error = false;
-      Object.keys(json.versions[newVersionKey]).forEach((directory) => {
-        const newFilePath = path.join(directory, newVersionKey);
-        if (json.versions[oldVersionKey][directory]) {
-          const oldFilePath = path.join(directory, oldVersionKey);
-          try {
-            fileDiff(
-              oldFilePath,
-              newFilePath,
-            )
-              .then((diff) => {
-                json.versions[newVersionKey][directory].diff = diff;
-              })
-              .catch((e) => {
-                error = e;
-              });
-          } catch (e) {
-            error = e;
-          }
+  public async fileDiffs (targetParentDirectory: string): Promise<any> {
+    const json = this.getCacheCompareJson(this.getCacheCompareConfigPath(targetParentDirectory));
+
+    const versions = Object.keys(json.versions).sort();
+    if (versions.length <= 1) {
+      console.log('No previous files to compare from, a diff comparison chart will be available after the next generation.');
+      return '';
+    }
+
+    const newVersionKey = versions.pop();
+    const oldVersionKey = versions.pop();
+
+    await Promise.all(
+      Object.keys(json.versions[newVersionKey]).map(async (directory) => {
+        if (!json.versions[oldVersionKey][directory]) {
+          return;
         }
-      });
-      return !error ? resolve(json.versions[newVersionKey]) : reject(error);
-    });
+
+        const oldFilePath = path.join(directory, oldVersionKey);
+        const newFilePath = path.join(directory, newVersionKey);
+        json.versions[newVersionKey][directory].diff = await fileDiff(oldFilePath, newFilePath);
+      })
+    );
+
+    return json.versions[newVersionKey];
   }
 
   /**
@@ -94,20 +85,26 @@ class GeneratedComparison {
    * @param outputDir
    * @param input
    */
-  public fileDiffsPrint (outputDir: string, input: any) {
+  public fileDiffsPrint (outputDir: string, input: any): void {
     if (typeof input === 'string' && input !== '') {
       return console.log(input);
     }
-    const logDiffs = {};
-    const cacheCompareDir = this.getCompareDirectory(outputDir);
-    const buildDiff = function (add: number, minus: number) {
-      this.added = add;
-      this.removed = minus;
-      this.message = (add > 0 || minus > 0) ? 'Diff print in full above' : 'No differences';
+
+    const buildDiff = (add: number, minus: number) => {
+      return {
+        added: add,
+        removed: minus,
+        message: add > 0 || minus > 0 ? 'Diff print in full above' : 'No differences',
+      };
     };
+
+    const logDiffs: Record<string, any> = {};
+    const cacheCompareDir = this.getCompareDirectory(outputDir);
+
     Object.keys(input).forEach((key) => {
       const displayPath = key.replace(cacheCompareDir, '');
-      if (input[key].diff && input[key].diff.difference && input[key].diff.difference.length > 0) {
+
+      if (input[key]?.diff?.difference?.length > 0) {
         console.log(consoleHorizontalRule());
         console.log('START' + displayPath.bold);
         console.log(input[key].diff.difference);
@@ -115,11 +112,7 @@ class GeneratedComparison {
         console.log(consoleHorizontalRule());
       }
 
-      // @ts-ignore
-      logDiffs[displayPath] = new buildDiff(
-        input[key].diff.plus,
-        input[key].diff.minus,
-      );
+      logDiffs[displayPath] = buildDiff(input[key].diff.plus, input[key].diff.minus);
     });
     console.table(logDiffs);
   }
@@ -129,7 +122,7 @@ class GeneratedComparison {
    * If the system has files not registered in the config, these files will remain untouched.
    * @param targetParentDirectory
    */
-  public versionCleanup (targetParentDirectory: string) {
+  public versionCleanup (targetParentDirectory: string): void {
     const configPath = this.getCacheCompareConfigPath(targetParentDirectory);
     const json = this.getCacheCompareJson(configPath);
     const versions = Object.keys(json.versions).sort().reverse();
@@ -163,16 +156,18 @@ class GeneratedComparison {
    * @param {string} newFileString - The newly rendered content
    * @return {Promise<void>}
    */
-  public async generateComparisonFile (targetFile: string, targetParentDirectory: string, subDirectory: string, newFilename: string, newFileString: string) {
+  public async generateComparisonFile (
+    targetFile: string,
+    targetParentDirectory: string,
+    subDirectory: string,
+    newFilename: string,
+    newFileString: string
+  ): Promise<void> {
     const backupComparePath = path.join(this.getCompareDirectory(targetParentDirectory), subDirectory, newFilename);
     const backUpFile = path.join(backupComparePath, '/', global.startISOString);
     fs.ensureFileSync(backUpFile);
     fs.ensureDirSync(backupComparePath);
-    this.addToCacheComparisonReport(
-      this.getCacheCompareConfigPath(targetParentDirectory),
-      backupComparePath,
-      global.startISOString,
-    );
+    this.addToCacheComparisonReport(this.getCacheCompareConfigPath(targetParentDirectory), backupComparePath, global.startISOString);
     return fs.writeFileSync(backUpFile, newFileString, 'utf8');
   }
 
@@ -183,7 +178,7 @@ class GeneratedComparison {
    * @param {string} isoTimstamp - Current runtime timestamp
    * @return {void}
    */
-  public addToCacheComparisonReport (jsonFilePath: string, backupComparePath: string, isoTimstamp: string) {
+  public addToCacheComparisonReport (jsonFilePath: string, backupComparePath: string, isoTimstamp: string): void {
     const json = this.getCacheCompareJson(jsonFilePath);
     if (!json.versions[isoTimstamp]) {
       json.versions[isoTimstamp] = {};

--- a/src/lib/generate/GeneratedComparison.ts
+++ b/src/lib/generate/GeneratedComparison.ts
@@ -65,17 +65,15 @@ class GeneratedComparison {
     const newVersionKey = versions.pop();
     const oldVersionKey = versions.pop();
 
-    await Promise.all(
-      Object.keys(json.versions[newVersionKey]).map(async (directory) => {
-        if (!json.versions[oldVersionKey][directory]) {
-          return;
-        }
+    for (const directory of Object.keys(json.versions[newVersionKey])) {
+      if (!json.versions[oldVersionKey][directory]) {
+        return;
+      }
 
-        const oldFilePath = path.join(directory, oldVersionKey);
-        const newFilePath = path.join(directory, newVersionKey);
-        json.versions[newVersionKey][directory].diff = await fileDiff(oldFilePath, newFilePath);
-      })
-    );
+      const oldFilePath = path.join(directory, oldVersionKey);
+      const newFilePath = path.join(directory, newVersionKey);
+      json.versions[newVersionKey][directory].diff = await fileDiff(oldFilePath, newFilePath);
+    }
 
     return json.versions[newVersionKey];
   }


### PR DESCRIPTION
Old closed ticket #42 might be resolved now.

Was doing some dev and hit the OOM issue quite a few times - tossed in some logs, tracked it down to the `GeneratedComparison.fileDiffs` method, did a little refactor and have not seen another one since.

Hard to say for sure though, as in the 100+ gen's I did, maybe 10 were OOMs? So might still be an issue, however there were definitely promises inside a forEach that were just floating around in the background, so it's likely that was at least part of the issue.