### PR TITLE
Map oa3 multipart content type to formData instead of body

### DIFF
--- a/src/__tests__/openapiNodegen_oa3.ts
+++ b/src/__tests__/openapiNodegen_oa3.ts
@@ -42,7 +42,7 @@ describe('e2e testing', () => {
       // Check domains (STUB file)
       [
         'test_server/src/domains/domainsImporter.ts',
-        '40c2afe0eb99354e208ba9833e9fbfd4',
+        'f320fd1f45c82774fce9cf19e42cd0a5',
       ],
       [
         'test_server/src/domains/WeatherDomain.ts',
@@ -56,7 +56,7 @@ describe('e2e testing', () => {
       // Check the interface index file (OTHER file)
       [
         'test_server/src/http/nodegen/interfaces/index.ts',
-        'db175959c900708e577b790970f7fee0',
+        '0a4658f2480054f9a3a416f358deee2f',
       ],
       // Check the security definition files (OTHER file)
       [

--- a/src/lib/openapi/oa3toOa2Body.ts
+++ b/src/lib/openapi/oa3toOa2Body.ts
@@ -1,24 +1,35 @@
 import { startCase } from 'lodash';
 
 export default (method: string, fullPathMethod: any): any => {
-  if (!fullPathMethod.requestBody || (Array.isArray(fullPathMethod.parameters) && fullPathMethod.parameters.some((param: any) => param.in === 'body'))) {
+  if (
+    !fullPathMethod.requestBody ||
+    (Array.isArray(fullPathMethod.parameters) && fullPathMethod.parameters.some((param: any) => param.in === 'body'))
+  ) {
     return fullPathMethod;
   }
   try {
-    let schema;
+    let schema = {};
+    let inParam = 'body';
+
     if (fullPathMethod.requestBody.content['application/json']) {
       schema = fullPathMethod.requestBody.content['application/json'].schema;
-    }
-    if (fullPathMethod.requestBody.content['application/x-www-form-urlencoded']) {
+    } else if (fullPathMethod.requestBody.content['application/x-www-form-urlencoded']) {
       schema = fullPathMethod.requestBody.content['application/x-www-form-urlencoded'].schema;
+    } else if (fullPathMethod.requestBody.content['multipart/form-data']) {
+      schema = fullPathMethod.requestBody.content['multipart/form-data'];
+      inParam = 'formData';
+    } else {
+      schema = Object.values(fullPathMethod.requestBody.content)?.[0];
     }
+
     fullPathMethod.parameters = fullPathMethod.parameters || [];
     fullPathMethod.parameters.push({
-      in: 'body',
+      in: inParam,
       name: fullPathMethod.operationId + startCase(method),
       required: fullPathMethod.requestBody.required,
-      schema: schema
+      schema,
     });
+
     return fullPathMethod;
   } catch (e) {
     console.log(fullPathMethod);

--- a/test_openapi3.yml
+++ b/test_openapi3.yml
@@ -159,6 +159,22 @@ paths:
           description: Round not found
       security:
         - apiToken: []
+  /weather-upload:
+    post:
+      tags:
+        - Wet-er
+      operationId: weatherUpload
+      summary: Upload new weather
+      description: Upload new weather (ie in case it's summer and you, a normal person, prefer winter)
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/WeatherUpload'
+      responses:
+        '201':
+          description: successful operation
 servers:
   - url: https://samples.openweathermap.org/data/2.5
   - url: https://api.example.com
@@ -344,3 +360,14 @@ components:
           type: string
         cod:
           type: number
+    WeatherUpload:
+      type: object
+      properties:
+        rain:
+          type: boolean
+        pdfAboutHowMuchBetterWinterIs:
+          type: string
+          format: binary
+        startDate:
+          type: string
+          format: date


### PR DESCRIPTION
Also added a catch all which would just take whatever the first content-type is and use that as body - will definitely not work if an endpoint supports multiple content type responses

closes acr-lfr/generate-it-typescript-server#164 
closes acr-lfr/generate-it-typescript-server#163