### PR TITLE
fix issue with file diff trying to print undefined / null

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-it",
-  "version": "5.33.0",
+  "version": "5.34.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-it",
-  "version": "5.33.0",
+  "version": "5.34.0",
   "description": "Generate-it, will generate servers, clients, web-socket and anything else you can template with nunjucks from yml files (openapi/asyncapi)",
   "author": "Acrontum GmbH & Liffery Ltd",
   "license": "MIT",

--- a/src/lib/generate/GeneratedComparison.ts
+++ b/src/lib/generate/GeneratedComparison.ts
@@ -67,7 +67,7 @@ class GeneratedComparison {
 
     for (const directory of Object.keys(json.versions[newVersionKey])) {
       if (!json.versions[oldVersionKey][directory]) {
-        return;
+        continue;
       }
 
       const oldFilePath = path.join(directory, oldVersionKey);
@@ -86,6 +86,9 @@ class GeneratedComparison {
   public fileDiffsPrint (outputDir: string, input: any): void {
     if (typeof input === 'string' && input !== '') {
       return console.log(input);
+    }
+    if (typeof input === 'undefined' || input === null) {
+      return;
     }
 
     const buildDiff = (add: number, minus: number) => {


### PR DESCRIPTION
Had this a few times in the output:
```
Nodegen directory structure ready
Something went wrong:
Trace: TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at GeneratedComparison.fileDiffsPrint (/test/node_modules/generate-it/build/lib/generate/GeneratedComparison.js:111:16)
    at /test/node_modules/generate-it/build/generateIt.js:48:50
    at step (/test/node_modules/tslib/tslib.js:143:27)
    at Object.next (/test/node_modules/tslib/tslib.js:124:57)
    at fulfilled (/test/node_modules/tslib/tslib.js:114:62)
    at /test/node_modules/generate-it/build/cli.js:43:25
    at step (/test/node_modules/tslib/tslib.js:143:27)
    at Object.next (/test/node_modules/tslib/tslib.js:124:57)
    at /test/node_modules/tslib/tslib.js:117:75
    at new Promise (<anonymous>)
    at Object.__awaiter (/test/node_modules/tslib/tslib.js:113:16)
    at /test/node_modules/generate-it/build/cli.js:40:53
```

The only difference after the refactor is that it early exits on the first version compare, so replaced that `return` with a `continue`, but just to be sure also tacked on a check in the printer