### PR TITLE
fix: validator function skips query param key when param is of type "object"

### DIFF
--- a/src/lib/helpers/SwaggerUtils.ts
+++ b/src/lib/helpers/SwaggerUtils.ts
@@ -174,6 +174,9 @@ class SwaggerUtils {
       validationText += `'${paramTypeKey}': Joi.object({`;
       paramsTypes[paramTypeKey].forEach((param: any) => {
         if (param.schema && param.schema.properties) {
+          if (paramTypeKey === 'query') {
+            validationText += `'${param.name}': Joi.object({`;
+          }
           Object.keys(param.schema.properties).forEach((propertyKey) => {
             validationText += this.pathParamsToJoi({
               name: propertyKey, ...param.schema.properties[propertyKey],
@@ -182,6 +185,9 @@ class SwaggerUtils {
               paramTypeKey: paramTypeKey as ParamTypeKey,
             });
           });
+          if (paramTypeKey === 'query') {
+            validationText += '}),';
+          }
         } else if (param.type || (param.schema && param.schema.type)) {
           validationText += this.pathParamsToJoi(param, {
             paramTypeKey: paramTypeKey as ParamTypeKey

--- a/src/lib/helpers/__tests__/SwaggerUtils.ts
+++ b/src/lib/helpers/__tests__/SwaggerUtils.ts
@@ -73,6 +73,16 @@ const params = [{
           },
         },
     },
+}, {
+  in: 'query',
+  name: 'objectInsideQuery',
+  schema: {
+    type: 'object',
+    properties: [{
+      name: 'prop1',
+      type: 'string'
+    }]
+  }
 }];
 
 test('Returns joi with 2 required params', () => {
@@ -158,5 +168,14 @@ test('add unknown true for headers', () => {
     }),
   ).toBe(
     `'headers': Joi.object({'sort':Joi.string().valid('asc', 'desc').required(),'access':Joi.string().regex(/^Bearer .+$/).required(),}).unknown(true),'query': Joi.object({'limit':Joi.number().integer(),}),`,
+  );
+});
+
+
+test('query item key is properly created inside the query object', () => {
+  expect(
+    SwaggerUtils.createJoiValidation('get', {parameters: [params[6]]}),
+  ).toBe(
+    `'query': Joi.object({'objectInsideQuery': Joi.object({'prop1':Joi.string().allow(''),}),}),`,
   );
 });


### PR DESCRIPTION
**Generated type (before and after the patch - right):**
```ts
export interface AdminProfilesGetQuery {
  dbQueryProfile?: DbQueryProfile;
}

export interface DbQueryProfile {
  filter?: // ...
}
```

**Generated validations (before the patch - wrong):**
```ts
export default {
  adminProfilesGet: {
    query: Joi.object({
       // ... key "dbQueryProfile" is missing :(
       filter: // ...
    })
  };
  ```
  
**Generated validations (after the patch - right):**
```ts
export default {
  adminProfilesGet: {
    query: Joi.object({
      dbQueryProfile: Joi.object({
         // ... key "dbQueryProfile" is here :)
         filter: // ...
      })
    })
  };
  ```