### PR TITLE
permit 1 service to publish and subscribe to the same id

### DIFF
--- a/src/lib/helpers/__tests__/checkRcOpIdArrIsValid.ts
+++ b/src/lib/helpers/__tests__/checkRcOpIdArrIsValid.ts
@@ -5,8 +5,8 @@ const nodegenRc: NodegenRc = {
   nodegenDir: 'blah',
   nodegenType: 'blah',
   helpers: {
-    publishOpIds: ['bob'],
-    subscribeOpIds: ['smith']
+    publishOpIds: ['bob', 'pubAndSubOnSameService'],
+    subscribeOpIds: ['smith', 'pubAndSubOnSameService']
   }
 };
 
@@ -16,6 +16,11 @@ const openapi = {
 
 const asyncapi = {
   channels: {
+    doBoth: {
+      publish: {
+        operationId: 'pubAndSubOnSameService'
+      }
+    },
     somepath: {
       publish: {
         operationId: 'bob'
@@ -61,8 +66,8 @@ it('should throw an error for asyncapi with invalid publish id', (done) => {
   }
 });
 
-it('should throw an error for asyncapi with any duplicate id', (done) => {
-  nodegenRc.helpers.publishOpIds.push('smith');
+it('should throw an error for asyncapi with any duplicate id in the pub list', (done) => {
+  nodegenRc.helpers.publishOpIds.push('bob');
   try {
     checkRcOpIdArrIsValid(asyncapi, nodegenRc);
     done('should have errored');
@@ -73,7 +78,7 @@ it('should throw an error for asyncapi with any duplicate id', (done) => {
 });
 
 it('should throw an error for asyncapi with any duplicate id', (done) => {
-  nodegenRc.helpers.subscribeOpIds.push('bob');
+  nodegenRc.helpers.subscribeOpIds.push('smith');
   try {
     checkRcOpIdArrIsValid(asyncapi, nodegenRc);
     done('should have errored');

--- a/src/lib/helpers/checkRcOpIdArrIsValid.ts
+++ b/src/lib/helpers/checkRcOpIdArrIsValid.ts
@@ -6,24 +6,26 @@ export default (apiObject: any, nodegenRc: NodegenRc) => {
     return true;
   }
 
-  const ids: string[] = [];
+  const subIds: string[] = [];
   nodegenRc.helpers?.subscribeOpIds?.forEach((item) => {
-    if (!ids.includes(item)) {
-      ids.push(item);
+    if (!subIds.includes(item)) {
+      subIds.push(item);
     } else {
       throw new Error('The nodegenrc file contains duplicate subscribeOpIds');
     }
   });
+
+  const pubIds: string[] = [];
   nodegenRc.helpers?.publishOpIds?.forEach((item) => {
-    if (!ids.includes(item)) {
-      ids.push(item);
+    if (!pubIds.includes(item)) {
+      pubIds.push(item);
     } else {
       throw new Error('The nodegenrc file contains duplicate publishOpIds');
     }
   });
 
   const idsToCompare = getOpIdsFromAsyncApi(apiObject);
-  ids.forEach((id) => {
+  pubIds.concat(subIds).forEach((id) => {
     if (!idsToCompare.includes(id)) {
       throw new Error('The nodegenrc file wants to PUBLISH or SUBSCRIBE to an id that does not exists in the async api file provided: ' + id);
     }


### PR DESCRIPTION
Please ensure your pull request:
- Includes additions to the docs, found in the /docs, as required
- The new and changed code you have written is unit tested and passes the eslint
- The body of the text for this PR includes enough text for a reviewer to understand the context of the change

Previously the code was wrong - it prevented the sub arr have the same id as on in the pub... what it should have been doing is stopping the user from have dupes in the sub and dupes in the pub.

This fix corrects the check and allows 1 service to pub and sub to the same opId