### PR TITLE
add express response to res with x-pass-response

### DIFF
--- a/src/__tests__/openapiNodegen_full.ts
+++ b/src/__tests__/openapiNodegen_full.ts
@@ -79,7 +79,7 @@ describe('e2e testing', () => {
       // Check rabbitMQ domains (STUB file)
       ['test_server/src/domains/domainsImporter.ts', '8502ae153a067f2832b991a4b6b4812a'],
       ['test_server/src/domains/WeatherDomain.ts', '30efe49b22921328e0be1ddc5c3e17a4'],
-      ['test_server/src/domains/RainDomain.ts', '2661960ee5787a58e824419d96c95cb4'],
+      ['test_server/src/domains/RainDomain.ts', '5a6a09b8828a9a89e38e0964e94e53e5'],
       // Check complex interface (INTERFACE file)
       ['test_server/src/http/nodegen/interfaces/WeatherFull.ts', 'ae5f4c579130f22b8d5aeb931a6fac74'],
       // Check the interface index file (OTHER file)

--- a/src/lib/template/helpers/pathParamsToDomainParams.ts
+++ b/src/lib/template/helpers/pathParamsToDomainParams.ts
@@ -92,17 +92,8 @@ export default function (method: string, pathObject: any, withType: boolean = fa
 
   // Inject the response to the params
   if (pathObject['x-passResponse'] && tplType !== 'client') {
-    if (fileType === 'STUB') {
-      params.push(
-        'res' + addType(
-        withType,
-        pathObject,
-        undefined,
-        undefined,
-        ));
-    } else {
-      params.push('res' + addType(withType, pathObject));
-    }
+    const type = withType ? ': Response' : '';
+    params.push(`res${type}`);
   }
 
   // sort the params object for uniform domain params!


### PR DESCRIPTION
 closes acr-lfr/generate-it-typescript-server#161 (pending acr-lfr/generate-it-typescript-server#179)

Please ensure your pull request:
- ~Includes additions to the docs, found in the /docs, as required~
- ~The new and changed code you have written is unit tested~ and passes the eslint
- The body of the text for this PR includes enough text for a reviewer to understand the context of the change (see issue)
