### PR TITLE
Feature/injections 

### DIFF
--- a/docs/_pages/features.md
+++ b/docs/_pages/features.md
@@ -184,6 +184,24 @@ Each set of templates will evolve their own specific attribute requirements. Add
 
 An example of a template specific custom attribute usage: https://github.com/acrontum/openapi-nodegen-typescript-server/blob/master/src/http/nodegen/routes/___op.ts.njk#L28
 
+## Overriding template code with code from another source
+
+Sometimes, the code of 1 template is ok, but you would like to change just a few lines somewhere in a managed folder.
+
+With injections this is possible.
+
+For example, you might generate a typescript server from [acr-lfr/generate-it-typescript-server](https://github.com/acr-lfr/generate-it-typescript-server) but would like change part of the [src/http/index.ts](https://github.com/acr-lfr/generate-it-typescript-server/blob/master/src/http/index.ts)
+```
+"injections": [
+  {
+    "source": "https://github.com/yourusername/ts-overwrites.git"
+  }
+],
+```
+
+With the above injection block, generate-it will clone the base template and then copy over all files from `yourusername/ts-overwrites` before generating any code. The end result would be a generation based on a merged set of files from the base and your injections. 
+
+
 ## .nodegenrc file
 For more details please read this page: [templates](/_pages/templates.md)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "generate-it",
-  "version": "5.36.0",
+  "version": "5.38.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "generate-it",
-      "version": "5.36.0",
+      "version": "5.38.0",
       "license": "MIT",
       "dependencies": {
         "@root/walk": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-it",
-  "version": "5.37.0",
+  "version": "5.38.0",
   "description": "Generate-it, will generate servers, clients, web-socket and anything else you can template with nunjucks from yml files (openapi/asyncapi)",
   "author": "Acrontum GmbH & Liffery Ltd",
   "license": "MIT",

--- a/src/generateIt.ts
+++ b/src/generateIt.ts
@@ -10,6 +10,7 @@ import generateDirectoryStructure from '@/lib/generate/generateDirectoryStructur
 import TemplateFetch from '@/lib/template/TemplateFetch';
 import OpenAPIBundler from '@/lib/openapi/OpenAPIBundler';
 import checkRcOpIdArrIsValid from '@/lib/helpers/checkRcOpIdArrIsValid';
+import Injections from '@/lib/Injections';
 
 /**
  * Generates a code skeleton for an API given an OpenAPI/Swagger file.
@@ -20,6 +21,8 @@ export default async (config: Config): Promise<boolean> => {
 
   const templatesDir = await TemplateFetch.resolveTemplateType(config.template, config.targetDir, config.dontUpdateTplCache);
   let extendedConfig = await ConfigMerger.base(config, templatesDir);
+
+  await Injections.go(extendedConfig);
 
   const apiObject = await OpenAPIBundler.bundle(config.swaggerFilePath, extendedConfig);
 
@@ -57,5 +60,6 @@ export default async (config: Config): Promise<boolean> => {
   } else {
     console.log('Completed'.green.bold);
   }
+
   return true;
 };

--- a/src/generateIt.ts
+++ b/src/generateIt.ts
@@ -19,10 +19,10 @@ import Injections from '@/lib/Injections';
 export default async (config: Config): Promise<boolean> => {
   globalHelpers(config.verbose, config.veryVerbose);
 
-  const templatesDir = await TemplateFetch.resolveTemplateType(config.template, config.targetDir, config.dontUpdateTplCache);
+  const templatesDir = await TemplateFetch.resolveTemplateType( config.template, config.targetDir, config.dontUpdateTplCache);
   let extendedConfig = await ConfigMerger.base(config, templatesDir);
 
-  await Injections.go(extendedConfig);
+  extendedConfig.templates = await Injections.init(extendedConfig);
 
   const apiObject = await OpenAPIBundler.bundle(config.swaggerFilePath, extendedConfig);
 

--- a/src/interfaces/ConfigExtendedBase.ts
+++ b/src/interfaces/ConfigExtendedBase.ts
@@ -3,7 +3,7 @@ import { NodegenRc } from '@/interfaces/NodegenRc';
 import { Package } from '@/interfaces/Package';
 import { Swagger } from '@/interfaces/Swagger';
 
-// TODO
+
 export type AsyncApi = Record<string, any>;
 
 export interface ConfigExtendedBase extends Config {

--- a/src/interfaces/NodegenRc.ts
+++ b/src/interfaces/NodegenRc.ts
@@ -1,3 +1,15 @@
+export interface Helpers {
+  publishOpIds?: string[],
+  subscribeOpIds?: string[],
+
+  [helperName: string]: any
+}
+
+export interface InjectionOverwrites {
+  targetDir: string,
+  url: string
+}
+
 export interface NodegenRc {
   nodegenDir: string;
   nodegenMockDir?: string;
@@ -5,9 +17,6 @@ export interface NodegenRc {
   interfaceStyle?: string;
   segmentFirstGrouping?: number;
   segmentSecondGrouping?: number;
-  helpers?: {
-    publishOpIds?: string[],
-    subscribeOpIds?: string[],
-    [helperName: string]: any
-  };
+  helpers?: Helpers;
+  injectionOverwrites?: InjectionOverwrites[];
 }

--- a/src/interfaces/NodegenRc.ts
+++ b/src/interfaces/NodegenRc.ts
@@ -1,13 +1,13 @@
 export interface Helpers {
-  publishOpIds?: string[],
-  subscribeOpIds?: string[],
+  publishOpIds?: string[];
+  subscribeOpIds?: string[];
 
-  [helperName: string]: any
+  [helperName: string]: any;
 }
 
-export interface InjectionOverwrites {
-  targetDir: string,
-  url: string
+export interface Injection {
+  destination?: string;
+  source: string;
 }
 
 export interface NodegenRc {
@@ -18,5 +18,5 @@ export interface NodegenRc {
   segmentFirstGrouping?: number;
   segmentSecondGrouping?: number;
   helpers?: Helpers;
-  injectionOverwrites?: InjectionOverwrites[];
+  injections?: Injection[];
 }

--- a/src/lib/Injections.ts
+++ b/src/lib/Injections.ts
@@ -1,0 +1,90 @@
+import { GIT_DIRECTORY } from '@/constants/CachePaths';
+import { ConfigExtendedBase } from '@/interfaces';
+import TemplateFetch from '@/lib/template/TemplateFetch';
+import fs from 'fs-extra';
+import * as walk from '@root/walk';
+import path from 'path';
+
+class Injections {
+  async go (extendedConfig: ConfigExtendedBase): Promise<void> {
+    const {injectionOverwrites} = extendedConfig.nodegenRc;
+
+    if (!extendedConfig.nodegenRc?.injectionOverwrites.length) {
+      return;
+    }
+
+    const baseMerged = this.createBase(extendedConfig);
+
+    for (let i = 0; i < injectionOverwrites.length; i++) {
+      const injectionConfig = injectionOverwrites[i];
+      // download the injections
+      const templatesDir = await TemplateFetch.resolveTemplateType(
+        injectionConfig.url,
+        extendedConfig.targetDir,
+        extendedConfig.dontUpdateTplCache
+      );
+      await this.mergeIntoMerged({
+        target: extendedConfig.targetDir,
+        mergeDir: baseMerged.subDir,
+        gitOverwrite: templatesDir.replace(
+          path.join(extendedConfig.targetDir, GIT_DIRECTORY),
+          ''
+        )
+      });
+    }
+  }
+
+  createBase (extendedConfig: ConfigExtendedBase): { fullPath: string, subDir: string } {
+    const newDirParts = extendedConfig.template.split('/');
+    newDirParts[newDirParts.length - 1] += '_merged';
+    const newDir = newDirParts.join('/');
+    fs.copySync(
+      extendedConfig.template,
+      newDir
+    );
+    return {
+      fullPath: newDir,
+      subDir: newDirParts[newDirParts.length - 1]
+    };
+  }
+
+  mergeIntoMerged (input: { target: string, gitOverwrite: string, mergeDir: string }): Promise<void> {
+
+    const overwriteFrom = path.join(
+      input.target,
+      GIT_DIRECTORY,
+      input.gitOverwrite
+    );
+
+    const mergeDir = path.join(
+      input.target,
+      GIT_DIRECTORY,
+      input.mergeDir
+    );
+
+    return walk.walk(overwriteFrom, async (err: Error, fullpath: string, dirent: fs.Dirent) => {
+      if (err) {
+        throw err;
+      }
+
+      const fullMergedPath = fullpath.replace(overwriteFrom, mergeDir);
+
+      if (dirent.isFile()) {
+        // ensure the directory lives in the merged folder
+        fs.ensureDirSync(
+          path.dirname(
+            fullMergedPath
+          )
+        );
+
+        // copy the file over
+        fs.copyFileSync(
+          fullpath,
+          fullMergedPath
+        );
+      }
+    });
+  }
+}
+
+export default new Injections();

--- a/src/lib/Injections.ts
+++ b/src/lib/Injections.ts
@@ -6,24 +6,35 @@ import * as walk from '@root/walk';
 import path from 'path';
 
 class Injections {
-  async go (extendedConfig: ConfigExtendedBase): Promise<void> {
-    const {injectionOverwrites} = extendedConfig.nodegenRc;
-
-    if (!extendedConfig.nodegenRc?.injectionOverwrites.length) {
-      return;
+  /**
+   * Based on the injections attribute of the nodegenrc file this will merge the injection
+   * files into the template files of this run
+   * @param extendedConfig
+   * @return Full path to the new merged template directory, or, the original
+   */
+  async init (extendedConfig: ConfigExtendedBase): Promise<string> {
+    // Return the original value of "templates" when no injections are present
+    if (!extendedConfig.nodegenRc.injections || !extendedConfig.nodegenRc.injections.length) {
+      return extendedConfig.templates;
     }
 
-    const baseMerged = this.createBase(extendedConfig);
+    const {injections} = extendedConfig.nodegenRc;
 
-    for (let i = 0; i < injectionOverwrites.length; i++) {
-      const injectionConfig = injectionOverwrites[i];
-      // download the injections
+    // Before starting, we need a folder for the merged code to live
+    const baseMerged = this.createBaseMergeTemplateFolder(extendedConfig);
+
+    // Iterate over each injection
+    for (let i = 0; i < injections.length; i++) {
+
+      // download the injections using the regular TemplateFetch class
       const templatesDir = await TemplateFetch.resolveTemplateType(
-        injectionConfig.url,
+        injections[i].source,
         extendedConfig.targetDir,
         extendedConfig.dontUpdateTplCache
       );
-      await this.mergeIntoMerged({
+
+      // Merge the injection tpl into the merge folder
+      await this.mergeInjectionIntoBaseMergeFolder({
         target: extendedConfig.targetDir,
         mergeDir: baseMerged.subDir,
         gitOverwrite: templatesDir.replace(
@@ -32,54 +43,63 @@ class Injections {
         )
       });
     }
+
+    return baseMerged.fullPath;
   }
 
-  createBase (extendedConfig: ConfigExtendedBase): { fullPath: string, subDir: string } {
-    const newDirParts = extendedConfig.template.split('/');
+  /**
+   * The merged folder is simple copy of the primary template, the injection code will be written on top of its contents
+   */
+  createBaseMergeTemplateFolder (extendedConfig: ConfigExtendedBase): { fullPath: string, subDir: string } {
+    const newDirParts = extendedConfig.templates.split('/');
     newDirParts[newDirParts.length - 1] += '_merged';
     const newDir = newDirParts.join('/');
-    fs.copySync(
-      extendedConfig.template,
-      newDir
-    );
+
+    fs.copySync(extendedConfig.templates, newDir, {
+      // do not copy over the .git folder
+      filter: (src) => !src.includes('.git')
+    });
+
     return {
       fullPath: newDir,
       subDir: newDirParts[newDirParts.length - 1]
     };
   }
 
-  mergeIntoMerged (input: { target: string, gitOverwrite: string, mergeDir: string }): Promise<void> {
+  /**
+   * Merging the injection on top of the merge folder, as this is run multiple time depending on the qty of injections
+   * the order of the injections is important.
+   */
+  mergeInjectionIntoBaseMergeFolder (input: { target: string, gitOverwrite: string, mergeDir: string }): Promise<void> {
+    const overwriteFrom = path.join(input.target, GIT_DIRECTORY, input.gitOverwrite);
+    const mergeDir = path.join(input.target, GIT_DIRECTORY, input.mergeDir);
 
-    const overwriteFrom = path.join(
-      input.target,
-      GIT_DIRECTORY,
-      input.gitOverwrite
-    );
-
-    const mergeDir = path.join(
-      input.target,
-      GIT_DIRECTORY,
-      input.mergeDir
-    );
-
-    return walk.walk(overwriteFrom, async (err: Error, fullpath: string, dirent: fs.Dirent) => {
+    return walk.walk(overwriteFrom, async (err: Error, fullPath: string, dirent: fs.Dirent) => {
       if (err) {
         throw err;
       }
 
-      const fullMergedPath = fullpath.replace(overwriteFrom, mergeDir);
+      // don't copy the got folder or contents over
+      if (fullPath.includes('.git')) {
+        return;
+      }
+
+      const fullMergedPath = fullPath.replace(overwriteFrom, mergeDir);
 
       if (dirent.isFile()) {
-        // ensure the directory lives in the merged folder
+        // Ensure the directory lives in the merged folder
+        // This permits the author of the injection source to inject
+        // totally new directories and files
         fs.ensureDirSync(
           path.dirname(
             fullMergedPath
           )
         );
 
-        // copy the file over
+        // copy the file over from the injection tpl
+        // to the new merged
         fs.copyFileSync(
-          fullpath,
+          fullPath,
           fullMergedPath
         );
       }

--- a/src/lib/template/__tests__/TemplateFetch.ts
+++ b/src/lib/template/__tests__/TemplateFetch.ts
@@ -65,7 +65,7 @@ describe('local folder structure', () => {
 
   it('accepts a local folder', async () => {
     fs.ensureDirSync(src);
-    fs.writeJsonSync(path.join(src, 'test.json'), { hello: 'world' });
+    fs.writeJsonSync(path.join(src, 'test.json'), {hello: 'world'});
 
     const cacheDirectory = TemplateFetch.calculateLocalDirectoryFromUrl(srcRoot, dest);
     await TemplateFetch.resolveTemplateType(srcRoot, dest, false);


### PR DESCRIPTION
This injector merges over files from tpl files in an opt'in fashion.

Example:

1. The original tpl repo: https://github.com/acr-lfr/generate-it-typescript-server 
2. The injector example repo: https://github.com/j-d-carmichael/test-injection-repo 
3. An example dummy API ( https://github.com/j-d-carmichael/api-dummy/tree/typeorm ):
   - Generated with the generate-it-typescript-server
   - .nodegenrc file contains the inection block
   - The injection references the aforementioned test-injeciton-repo

What happens when the generate-server on the dummy api:

1. normal ts server tpl is downloaded
2. sees the injection block in the rc file (https://github.com/j-d-carmichael/api-dummy/blob/typeorm/.nodegenrc#L7)
3. creates a new "_merged" folder (a copy of the previously downloaded tpl, minus the .git [this is not needed and created issues])
4. now it loops over all injection sources in the injection block
   - downloads the source
   - merges the source into the _merged folder
5. Finally, the injection.init returns the newly found templates system filepath
6. Genetate-it core continues oblivious to the hack.

The output of the example:
1. Everything is the same as the base template except any overwrites from the injection.
   - src/http/index.ts https://github.com/j-d-carmichael/api-dummy/blob/typeorm/src/http/index.ts#L32  the additional injections have been snipered out via the code injection


All previous tests work just the same. It is as if it was never there.

