### PR TITLE
feat: Allow custom QuickType options in .nodegenrc

### DIFF
--- a/docs/_pages/templates.md
+++ b/docs/_pages/templates.md
@@ -44,6 +44,9 @@ More extensive example:
       "throwErrorOnAlien": false,
       "allowNullishKeys": true
     }
+  },
+  "quickTypeOptions": {
+    "prefer-unions": false
   }
 }
 ```
@@ -52,9 +55,10 @@ More extensive example:
 
 | Option        | Type               | Default                                                                | Example                 | Comment                                                                                                                                                                                                                                                        |
 |---------------|--------------------|------------------------------------------------------------------------|-------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ignoreFiles   | string or string[] | ['\\.idea', '\\.git', '\\.vscode', 'node_modules', 'build', 'dist']    | ignoreFiles: ['target'] | If specified, ignores files matching the pattern or list (eg binaries, build outputs, etc). Values are parsed as regular expressions                                                                                                                           |
-| renderOnlyExt | string             | '*'     | ignoreFiles: '.njk'                                          | If specified, will only render files with the extension provided and simply copy everything else.                                                                                                                                                                                        |
-| dontPrettify  | boolean            | false   | dontPrettify: true                                           | If true, prevents running `prettier` on files after rendering.                                                                                                                                                                                                                           |
+| ignoreFiles      | string or string[]  | ['\\.idea', '\\.git', '\\.vscode', 'node_modules', 'build', 'dist']    | ignoreFiles: ['target'] | If specified, ignores files matching the pattern or list (eg binaries, build outputs, etc). Values are parsed as regular expressions                                                                                                                           |
+| renderOnlyExt    | string              | '*'     | ignoreFiles: '.njk'                                           | If specified, will only render files with the extension provided and simply copy everything else.                                                                                                                                                                                        |
+| dontPrettify     | boolean             | false   | dontPrettify: true                                           | If true, prevents running `prettier` on files after rendering.                                                                                                                                                                                                                           |
+| quickTypeOptions | Record<string, any> | {}      | "quickTypeOptions": { "prefer-unions": true }                                              | Specifies additional options for QuickType when converting schemas to types |
 
 The full contents of the nodegenrc file are passed to the templates within the config: [TemplateVariables.ts](https://github.com/acr-lfr/generate-it/blob/master/src/interfaces/TemplateVariables.ts)
 
@@ -82,7 +86,7 @@ The `___op.ts.njk` files generally live in the `nodegenDir` of the folder struct
 
 Named: [\___interface.ts.njk](https://github.com/acr-lfr/generate-it-typescript-server/blob/master/src/http/nodegen/interfaces/___interface.ts.njk)
 
-This type of file is rewritten every single time the core is run, it only ever contains interface code, currently only for typescript files. 
+This type of file is rewritten every single time the core is run, it only ever contains interface code, currently only for typescript files.
 
 The `___interface.ts.njk` files generally live in the `nodegenDir` of the folder structure.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "generate-it",
-  "version": "5.39.0",
+  "version": "5.38.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "generate-it",
-      "version": "5.39.0",
+      "version": "5.38.0",
       "license": "MIT",
       "dependencies": {
         "@root/walk": "^1.1.0",
@@ -26,7 +26,7 @@
         "nunjucks": "^3.2.3",
         "prettier": "^2.4.1",
         "project-name-generator": "^2.1.9",
-        "quicktype": "^15.0.260",
+        "quicktype": "^15.0.261",
         "recursive-copy": "^2.0.13",
         "semver": "^7.3.5",
         "text-file-diff": "1.1.2",
@@ -6302,9 +6302,9 @@
       }
     },
     "node_modules/quicktype": {
-      "version": "15.0.260",
-      "resolved": "https://registry.npmjs.org/quicktype/-/quicktype-15.0.260.tgz",
-      "integrity": "sha512-OYP77enVz2UkcdDqVFc2AcFGYjk5/ENGYZHmSEY5Oy6Y2xVatlHUnrScddEkI+xJxSfYS6UXSH8oOTW7mEOiEw==",
+      "version": "15.0.261",
+      "resolved": "https://registry.npmjs.org/quicktype/-/quicktype-15.0.261.tgz",
+      "integrity": "sha512-y2Se/GFGSeFNfON7X0MEJO8K+Lm23hWEZs5UMP9dVy3ShSYng6HTVw1YmqreUwGCLRGn4jD9TjNB1oqyaT3NBw==",
       "dependencies": {
         "@mark.probst/typescript-json-schema": "~0.32.0",
         "@mark.probst/unicode-properties": "~1.1.0",
@@ -6317,7 +6317,7 @@
         "is-url": "^1.2.4",
         "isomorphic-fetch": "^2.2.1",
         "js-base64": "^2.4.3",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "moment": "^2.22.1",
         "node-fetch": "^2.6.1",
         "pako": "^1.0.6",
@@ -6326,7 +6326,7 @@
         "stream-json": "1.1.3",
         "string-to-stream": "^1.1.0",
         "typescript": "~3.2.1",
-        "urijs": "^1.19.4",
+        "urijs": "^1.19.6",
         "uuid": "^3.2.1",
         "wordwrap": "^1.0.0",
         "yaml": "^1.5.0"
@@ -12890,9 +12890,9 @@
       "dev": true
     },
     "quicktype": {
-      "version": "15.0.260",
-      "resolved": "https://registry.npmjs.org/quicktype/-/quicktype-15.0.260.tgz",
-      "integrity": "sha512-OYP77enVz2UkcdDqVFc2AcFGYjk5/ENGYZHmSEY5Oy6Y2xVatlHUnrScddEkI+xJxSfYS6UXSH8oOTW7mEOiEw==",
+      "version": "15.0.261",
+      "resolved": "https://registry.npmjs.org/quicktype/-/quicktype-15.0.261.tgz",
+      "integrity": "sha512-y2Se/GFGSeFNfON7X0MEJO8K+Lm23hWEZs5UMP9dVy3ShSYng6HTVw1YmqreUwGCLRGn4jD9TjNB1oqyaT3NBw==",
       "requires": {
         "@mark.probst/typescript-json-schema": "~0.32.0",
         "@mark.probst/unicode-properties": "~1.1.0",
@@ -12905,7 +12905,7 @@
         "is-url": "^1.2.4",
         "isomorphic-fetch": "^2.2.1",
         "js-base64": "^2.4.3",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "moment": "^2.22.1",
         "node-fetch": "^2.6.1",
         "pako": "^1.0.6",
@@ -12914,7 +12914,7 @@
         "stream-json": "1.1.3",
         "string-to-stream": "^1.1.0",
         "typescript": "~3.2.1",
-        "urijs": "^1.19.4",
+        "urijs": "^1.19.6",
         "uuid": "^3.2.1",
         "wordwrap": "^1.0.0",
         "yaml": "^1.5.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "generate-it",
-  "version": "5.38.0",
+  "version": "5.39.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "generate-it",
-      "version": "5.38.0",
+      "version": "5.39.0",
       "license": "MIT",
       "dependencies": {
         "@root/walk": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-it",
-  "version": "5.39.0",
+  "version": "5.38.0",
   "description": "Generate-it, will generate servers, clients, web-socket and anything else you can template with nunjucks from yml files (openapi/asyncapi)",
   "author": "Acrontum GmbH & Liffery Ltd",
   "license": "MIT",
@@ -53,7 +53,7 @@
     "nunjucks": "^3.2.3",
     "prettier": "^2.4.1",
     "project-name-generator": "^2.1.9",
-    "quicktype": "^15.0.260",
+    "quicktype": "^15.0.261",
     "recursive-copy": "^2.0.13",
     "semver": "^7.3.5",
     "text-file-diff": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-it",
-  "version": "5.38.0",
+  "version": "5.39.0",
   "description": "Generate-it, will generate servers, clients, web-socket and anything else you can template with nunjucks from yml files (openapi/asyncapi)",
   "author": "Acrontum GmbH & Liffery Ltd",
   "license": "MIT",

--- a/src/__mocks__/mockConfig.ts
+++ b/src/__mocks__/mockConfig.ts
@@ -1,0 +1,16 @@
+import { ConfigExtendedBase } from '@/interfaces';
+
+export const mockConfig: ConfigExtendedBase = {
+  swaggerFilePath: '',
+  targetDir: '',
+  template: 'Test',
+  dontUpdateTplCache: false,
+  dontRunComparisonTool: false,
+  updateDependenciesFromTpl: false,
+  mockServer: false,
+  nodegenRc: {
+    nodegenDir: 'src/http',
+    nodegenMockDir: 'src/domains/__mocks__',
+    nodegenType: 'server'
+  }
+};

--- a/src/interfaces/NodegenRc.ts
+++ b/src/interfaces/NodegenRc.ts
@@ -38,4 +38,13 @@ export interface NodegenRc {
    * Let the template project decides if it should run prettier.
    */
   dontPrettify?: boolean;
+  /**
+   * Extra options to pass to quicktype when generating types.
+   * NOTE: Defaults like 'acronym-style' and 'just-types' are not overridable.
+   *
+   * Example, use unions instead of enums in TypeScript: {
+   *   'prefer-unions': true
+   * }
+   */
+  quickTypeOptions?: Record<string, string>;
 }

--- a/src/lib/__tests__/OpenAPIInjectInterfaceNaming.ts
+++ b/src/lib/__tests__/OpenAPIInjectInterfaceNaming.ts
@@ -1,14 +1,16 @@
 
+import { ConfigExtendedBase } from '@/interfaces';
 import OpenAPIInjectInterfaceNaming from '@/lib/openapi/OpenAPIInjectInterfaceNaming';
+import { mockConfig } from '@/__mocks__/mockConfig';
 
 const swagger2obj = {
   swagger: '2.0',
 };
-const initialisedSwagger = new OpenAPIInjectInterfaceNaming(swagger2obj);
+const initialisedSwagger = new OpenAPIInjectInterfaceNaming(swagger2obj, mockConfig);
 const openApiobj = {
   openapi: '3.0.0',
 };
-const initialisedOpenApi = new OpenAPIInjectInterfaceNaming(openApiobj);
+const initialisedOpenApi = new OpenAPIInjectInterfaceNaming(openApiobj, mockConfig);
 
 describe('Initialise and validate file type checks', () => {
   it('Should inject an open api object', () => {

--- a/src/lib/generate/__tests__/generateTypeScriptInterfaceText.ts
+++ b/src/lib/generate/__tests__/generateTypeScriptInterfaceText.ts
@@ -1,4 +1,6 @@
+import { ConfigExtendedBase } from '@/interfaces';
 import generateTypeScriptInterfaceText from '@/lib/generate/generateTypeScriptInterfaceText';
+import { mockConfig } from '@/__mocks__/mockConfig';
 
 describe('generateTypeScriptInterfaceText', () => {
   it('should convert a schema to the correct type', async () => {
@@ -7,7 +9,7 @@ describe('generateTypeScriptInterfaceText', () => {
       "type": "object",
       "properties": { "lon": { "type": "number" }, "lat": { "type": "number" } }
     }
-    `);
+    `, mockConfig);
     expect(output.outputString.trim()).toBe(
       'export interface Person {\n' +
       '    lat?: number;\n' +
@@ -21,7 +23,7 @@ describe('generateTypeScriptInterfaceText', () => {
     {
       "type": "string"
     }
-    `);
+    `, mockConfig);
     expect(output.outputString.trim()).toBe('export type UserId = string;');
   });
 
@@ -33,7 +35,7 @@ describe('generateTypeScriptInterfaceText', () => {
         "type": "string"
       }
     }
-    `);
+    `, mockConfig);
     expect(output.outputString.trim()).toBe('export type UserId = string[];');
   });
 
@@ -47,7 +49,7 @@ describe('generateTypeScriptInterfaceText', () => {
         "type": "string"
       }
     }
-    `);
+    `, mockConfig);
     expect(output.outputString.trim()).toBe('export type NamibianCities = string[];');
   });
 
@@ -59,7 +61,7 @@ describe('generateTypeScriptInterfaceText', () => {
         "type": "string"
       }
     }
-    `);
+    `, mockConfig);
     expect(output.outputString.trim()).toBe('export type UserMap = { [key: string]: string };');
   });
 
@@ -76,12 +78,52 @@ describe('generateTypeScriptInterfaceText', () => {
         }
       }
     }
-    `);
+    `, mockConfig);
     expect(output.outputString.trim()).toBe(
       'export type Users = User[];\n\n' +
       'export interface User {\n' +
       '    name?: string;\n' +
       '}'
+    );
+  });
+
+  it('should create an enum', async () => {
+    const output = await generateTypeScriptInterfaceText('EnumItIs', `
+    {
+      "type": "string",
+      "enum": ["yay", "hey", "it works!"]
+    }
+    `, mockConfig);
+
+    expect(output.outputString.trim()).toBe(
+      'export enum EnumItIs {\n' +
+      '    Hey = "hey",\n' +
+      '    ItWorks = "it works!",\n' +
+      '    Yay = "yay",\n' +
+      '}'
+    );
+  });
+
+  it('should create an union', async () => {
+    const unionConfig = {
+      ...mockConfig,
+      nodegenRc: {
+        ...mockConfig.nodegenRc,
+        quickTypeOptions: {
+          'prefer-unions': 'true'
+        }
+      }
+    };
+
+    const output = await generateTypeScriptInterfaceText('WeAreUnion', `
+    {
+      "type": "string",
+      "enum": ["yay", "hey", "it works!"]
+    }
+    `, unionConfig);
+
+    expect(output.outputString.trim()).toBe(
+      'export type WeAreUnion = "yay" | "hey" | "it works!";'
     );
   });
 });

--- a/src/lib/generate/generateTypeScriptInterfaceText.ts
+++ b/src/lib/generate/generateTypeScriptInterfaceText.ts
@@ -1,4 +1,5 @@
 import { LINEBREAK } from '@/constants/cli';
+import { ConfigExtendedBase } from '@/interfaces';
 import { GenerateTypeScriptInterfaceText } from '@/interfaces/GenerateTypeScriptInterfaceText';
 
 const { InputData, JSONSchemaInput, JSONSchemaStore, quicktype } = require('quicktype/dist/quicktype-core');
@@ -8,7 +9,7 @@ const countNoOfMatches = (name: string, line: string): number => {
   return ((line || '').match(regex) || []).length;
 };
 
-export default async (name: string, schema: string): Promise<GenerateTypeScriptInterfaceText> => {
+export default async (name: string, schema: string, config: ConfigExtendedBase): Promise<GenerateTypeScriptInterfaceText> => {
   const schemaInput = new JSONSchemaInput(new JSONSchemaStore());
   await schemaInput.addSource({
     name: '___Nodegen',
@@ -27,6 +28,7 @@ export default async (name: string, schema: string): Promise<GenerateTypeScriptI
     inputData,
     lang: 'ts',
     rendererOptions: {
+      ...(config.nodegenRc?.quickTypeOptions || {}),
       'just-types': true,
       'acronym-style': 'original',
     },

--- a/src/lib/openapi/OpenAPIBundler.ts
+++ b/src/lib/openapi/OpenAPIBundler.ts
@@ -140,9 +140,9 @@ class OpenAPIBundler {
    */
   public async injectInterfaces (apiObject: any, config: ConfigExtendedBase) {
     apiObject.interfaces = [];
-    apiObject = await this.injectDefinitionInterfaces(apiObject);
+    apiObject = await this.injectDefinitionInterfaces(apiObject, config);
     if (ApiIs.isOpenAPIorSwagger(apiObject)) {
-      apiObject = await this.injectParameterInterfaces(apiObject);
+      apiObject = await this.injectParameterInterfaces(apiObject, config);
     } else if (ApiIs.asyncapi2(apiObject)) {
       // TODO complete the parameters for async api apiObject = await this.injectParameterInterfacesFromAsyncApi(apiObject, config);
       // TODO this was left as not required for rabbitmq
@@ -157,7 +157,7 @@ class OpenAPIBundler {
    * @param apiObject
    * @return apiObject
    */
-  public async injectDefinitionInterfaces (apiObject: any): Promise<any> {
+  public async injectDefinitionInterfaces (apiObject: any, config: ConfigExtendedBase): Promise<any> {
     // edge case for api's without any definitions or component schemas
     if (ApiIs.swagger(apiObject) && !apiObject.definitions
       || ApiIs.openapi3(apiObject) && (!apiObject.components || !apiObject.components.schemas)) {
@@ -177,6 +177,7 @@ class OpenAPIBundler {
           content: await generateTypeScriptInterfaceText(
             defKeys[i],
             JSON.stringify(definitionObject),
+            config
           ),
         });
       } catch (e) {
@@ -191,7 +192,7 @@ class OpenAPIBundler {
   /**
    * Iterates over all path generating interface texts from the json schema in the request definitions
    */
-  public async injectParameterInterfaces (apiObject: any) {
+  public async injectParameterInterfaces (apiObject: any, config: ConfigExtendedBase) {
     // iterate over paths with for loop so can use await later
     const pathsKeys = Object.keys(apiObject.paths);
     for (let i = 0; i < pathsKeys.length; ++i) {
@@ -229,6 +230,7 @@ class OpenAPIBundler {
                 apiObject,
                 param.path,
               )),
+              config
             );
             apiObject.interfaces.push({
               name: param.name,

--- a/src/lib/openapi/OpenAPIInjectInterfaceNaming.ts
+++ b/src/lib/openapi/OpenAPIInjectInterfaceNaming.ts
@@ -11,7 +11,7 @@ class OpenAPIInjectInterfaceNaming {
   public config: any;
   public apiObject: any;
 
-  constructor (jsObject: any, passedConfig?: ConfigExtendedBase) {
+  constructor (jsObject: any, passedConfig: ConfigExtendedBase) {
     this.apiObject = jsObject;
     this.config = passedConfig || {};
   }
@@ -299,7 +299,11 @@ class OpenAPIInjectInterfaceNaming {
         const interfaceName = this.apiObject[action][path][method]['x-request-definitions'][requestType].name;
         this.apiObject[action][path][method]['x-request-definitions'][requestType].interfaceText = (['body', 'formData'].includes(requestType))
           ? {outputString: this.objectToInterfaceString(requestObject, interfaceName)}
-          : await generateTypeScriptInterfaceText(interfaceName, JSON.stringify({type: 'object', properties: requestObject}));
+          : await generateTypeScriptInterfaceText(
+            interfaceName,
+            JSON.stringify({type: 'object', properties: requestObject}),
+            this.config
+          );
       } else {
         delete this.apiObject[action][path][method]['x-request-definitions'][requestType];
       }


### PR DESCRIPTION
Allow custom QuickType options in .nodegenrc (i.e. `"prefer-unions": true`).
There are no changes to the existing behavior, since this is only an opt-in, not opt-out feature.
