### PR TITLE
ensure attributes are wrapped when needed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "generate-it",
-  "version": "5.51.0",
+  "version": "5.52.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "generate-it",
-      "version": "5.51.0",
+      "version": "5.52.0",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-it",
-  "version": "5.51.0",
+  "version": "5.52.0",
   "description": "Generate-it, will generate servers, clients, web-socket and anything else you can template with nunjucks from yml files (openapi/asyncapi)",
   "author": "Acrontum GmbH & Liffery Ltd",
   "license": "MIT",

--- a/src/lib/helpers/OaToJsToJs.ts
+++ b/src/lib/helpers/OaToJsToJs.ts
@@ -27,15 +27,20 @@ class OaToJsToJs {
     return builtString.substring(0, builtString.length - 2);
   }
 
+  shouldWrapAttribute (key: string): boolean {
+    return !Boolean(key.match(/^[A-Za-z0-9_]*$/));
+  }
+
   public objectWalkWrite (input: any, builtString?: string) {
     builtString = builtString || '{';
     for (const key in input) {
+      const objectKey = this.shouldWrapAttribute(key) ? `['${key}']` : key;
       if (typeof input[key] === 'function') {
-        builtString += key + ': ' + this.getType(input[key]) + `, `;
+        builtString += objectKey + ': ' + this.getType(input[key]) + `, `;
       } else if (Array.isArray(input[key])) {
-        builtString += key + ': [' + this.arrayWalkWrite(input[key]) + '],';
+        builtString += objectKey + ': [' + this.arrayWalkWrite(input[key]) + '],';
       } else if (typeof input[key] === 'object') {
-        builtString += key + ': ' + this.objectWalkWrite(input[key]);
+        builtString += objectKey + ': ' + this.objectWalkWrite(input[key]);
       }
     }
     builtString += '},';

--- a/src/lib/helpers/__tests__/OaToJsToJs.spec.ts
+++ b/src/lib/helpers/__tests__/OaToJsToJs.spec.ts
@@ -1,0 +1,19 @@
+import OaToJsToJs from '@/lib/helpers/OaToJsToJs';
+
+it('shouldWrapAttribute should return correct values', async () => {
+  expect(OaToJsToJs.shouldWrapAttribute('hello')).toBe(false);
+  expect(OaToJsToJs.shouldWrapAttribute('hello_world')).toBe(false);
+  expect(OaToJsToJs.shouldWrapAttribute('hello world')).toBe(true);
+  expect(OaToJsToJs.shouldWrapAttribute('hello-world')).toBe(true);
+});
+
+it('should build a string from an object correctly', async () => {
+  const input = {
+    hi: String,
+    mid_way: {
+      wheel: String
+    },
+    'end of the line': Number
+  };
+  expect(OaToJsToJs.objectWalkWrite(input)).toBe('{hi: String, mid_way: {wheel: String, },[\'end of the line\']: Number, },');
+});


### PR DESCRIPTION
Create an attribute in a key with a - and previously it would break the function paramsOutputReducer.ts

This PR now checks if the key should be wrapped and wraps it in ['  ']