### PR TITLE
feat: injections can delete files

### DIFF
--- a/docs/_pages/features.md
+++ b/docs/_pages/features.md
@@ -247,7 +247,10 @@ To make this simpler, turn the whole process around.
         "source": "https://github.com/acr-lfr/generate-it-typescript-server.git"
      }
      {
-        "source": "https://github.com/yourusername/ts-overwrites"
+        "source": "https://github.com/yourusername/ts-overwrites",
+        "deleteFiles": [
+          "src/services/PermissionService.ts"
+        ]
      }
    ]
 }
@@ -263,7 +266,8 @@ What will happen now:
       - If you place the boolean on more than 1 injection object an error is thrown.
       - You can mark any injection to be the base.
       - TIP: It is advisable to use this flag as it offsets the dependency management to the authors of the base tpl.
-3. The end/final result will be your API now contains a combination of the injection tpls.
+   4. During the merge an array of files to remove from the merged director is collected. After all are collected, each will be removed from the merged folder.
+3. The end/final result will be your API now contains a combination of the injection tpls, but without the PermissionService.ts file.
    1. The base tpl management can be left to whoever manages it.
    2. You can inject your changes as required and manage updates to the changes remotely, changes will be pulled in on next call of generate-it.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "generate-it",
-  "version": "5.52.0",
+  "version": "5.53.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "generate-it",
-      "version": "5.52.0",
+      "version": "5.53.0",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-it",
-  "version": "5.52.0",
+  "version": "5.53.0",
   "description": "Generate-it, will generate servers, clients, web-socket and anything else you can template with nunjucks from yml files (openapi/asyncapi)",
   "author": "Acrontum GmbH & Liffery Ltd",
   "license": "MIT",

--- a/src/__tests__/openapiNodegen_full.ts
+++ b/src/__tests__/openapiNodegen_full.ts
@@ -114,6 +114,9 @@ it('The injected example file and random other injected file should be there ', 
   expect(fs.existsSync(path.join(process.cwd(), 'test_server/src/EXAMPLE_app.ts'))).toBe(true);
   expect(fs.existsSync(path.join(process.cwd(), 'test_server/src/someotherfile.ts'))).toBe(true);
 });
+it('The injections, it should have removed the "src/services/PermissionService.ts"', async () => {
+  expect(fs.existsSync(path.join(process.cwd(), 'test_server/src/services/PermissionService.ts'))).toBe(false);
+});
 
 it('The injections should have merged the package json files using the main server as the is base', async () => {
   const json = fs.readJsonSync(path.join(process.cwd(), 'test_server/package.json'));
@@ -127,7 +130,6 @@ it('The injections should have merged the package json files using the main serv
   expect(json.dependencies.cors).toBe('^2.8.5');
   expect(json.devDependencies.typescript).toBe('^3.6.4');
 });
-
 
 it(`shouldn't mangle package.json`, async () => {
   const jsonfile = path.join(testServerPath, 'package.json');

--- a/src/interfaces/NodegenRc.ts
+++ b/src/interfaces/NodegenRc.ts
@@ -14,6 +14,7 @@ export interface Injection {
    */
   isBaseTpl?: boolean;
   source: string;
+  deleteFiles?: string[];
 }
 
 export interface NodegenRc {

--- a/src/lib/Injections.ts
+++ b/src/lib/Injections.ts
@@ -39,9 +39,14 @@ class Injections {
     const baseMerged = this.createBaseMergeTemplateFolder(extendedConfig);
 
     const tplsFetched: TplsFetched = [];
+    let filesToDelete: string[] = [];
 
     // Iterate over each injection
     for (let i = 0; i < injections.length; i++) {
+
+      if (Array.isArray(injections[i].deleteFiles) && injections[i].deleteFiles.length) {
+        filesToDelete = filesToDelete.concat(injections[i].deleteFiles);
+      }
 
       // download the injections using the regular TemplateFetch class
       const templatesDir = await TemplateFetch.resolveTemplateType(
@@ -65,6 +70,14 @@ class Injections {
           ''
         )
       });
+    }
+
+    // remove any files marked to delete from the merged source folder
+    for (let i = 0; i < filesToDelete.length; i++) {
+      fs.removeSync(path.join(
+        baseMerged.fullPath,
+        filesToDelete[i]
+      ));
     }
 
     // finally, use the tplsFetched to merge together the dependency files - currently only supports package.json

--- a/test_server/.openapi-nodegen/git/httpsGithubComAcrontumOpenapiNodegenTypescriptServerGit/.nodegenrc
+++ b/test_server/.openapi-nodegen/git/httpsGithubComAcrontumOpenapiNodegenTypescriptServerGit/.nodegenrc
@@ -14,7 +14,10 @@
       "isBaseTpl": true
     },
     {
-      "source": "https://github.com/acrontum/openapi-nodegen-typescript-inject-server.git"
+      "source": "https://github.com/acrontum/openapi-nodegen-typescript-inject-server.git",
+      "deleteFiles": [
+        "src/services/PermissionService.ts"
+      ]
     }
   ]
 }


### PR DESCRIPTION
As the title says

```
"injections": [
     {
        "isBaseTpl": true
        "source": "https://github.com/acr-lfr/generate-it-typescript-server.git"
     }
     {
        "source": "https://github.com/yourusername/ts-overwrites",
        "deleteFiles": [
          "src/services/PermissionService.ts"
        ]
     }
   ]
```

You can place the deleteFiles in any injection object, they will be removed from the merge file before generate-it generates the output. 

This is a missing feature of injections - for example, we brought the permission and access service to common helpers for central control. We override this in our injection tpl

src/http/nodegen/middleware/accessTokenMiddleware.ts:
```
export default (headerNames: string[], options?: ValidateRequestOptions) => {
  return (req: NodegenRequest, res: express.Response, next: express.NextFunction) => {
    /**
     * The validate request should call the next function on successful token validation
     */
    AccessTokenService.validateRequest({
      req,
      res,
      next,
      headerNames,
      options,
      serverApiKey: config.apiKey,
      jwtSecret: config.jwtSecret
    });
  };
}
```

So we just have the original access and permission service files kicking around for no reason... but they keep getting added in again on regen. This way we explicitly mark the files to not reappear 