### PR TITLE
Feature/array path methods have attr

### DIFF
--- a/src/lib/template/helpers/__tests__/pathMethodsHaveAttr.ts
+++ b/src/lib/template/helpers/__tests__/pathMethodsHaveAttr.ts
@@ -1,7 +1,7 @@
 import pathMethodsHaveAttr from '@/lib/template/helpers/pathMethodsHaveAttr';
 import { Operation } from '@/interfaces';
 
-it('should return undefined', () => {
+it('should return true for a known attribute security provided', () => {
   const operations = [{
     path: {
       post: {
@@ -12,7 +12,7 @@ it('should return undefined', () => {
   expect(pathMethodsHaveAttr(operations as unknown as Operation[], 'security')).toBe(true);
 });
 
-it('should return undefined', () => {
+it('should return true for an attribute not in th path object', () => {
   const operations = [{
     path: {
       post: {
@@ -20,10 +20,10 @@ it('should return undefined', () => {
       }
     }
   }];
-  expect(pathMethodsHaveAttr(operations as unknown as Operation[], 'security', 'jwtToken')).toBe(false);
+  expect(pathMethodsHaveAttr(operations as unknown as Operation[], 'alien')).toBe(false);
 });
 
-it('should return true', () => {
+it('should return true for a path attr and a nested path, security and jwtToken', () => {
   const operations = [{
     path: {
       post: {
@@ -37,7 +37,18 @@ it('should return true', () => {
   expect(pathMethodsHaveAttr(operations as unknown as Operation[], 'security', 'jwtToken')).toBe(true);
 });
 
-it('should return false', () => {
+it('should return false for a known attr, security, and an known nested path jwtToken', () => {
+  const operations = [{
+    path: {
+      post: {
+        'security': [{apiKey: ''}],
+      }
+    }
+  }];
+  expect(pathMethodsHaveAttr(operations as unknown as Operation[], 'security', 'jwtToken')).toBe(false);
+});
+
+it('should return false for multiple paths, known attributes and no known nested path', () => {
   const operations = [{
     path: {
       post: {
@@ -54,7 +65,7 @@ it('should return false', () => {
   expect(pathMethodsHaveAttr(operations as unknown as Operation[], 'security', 'jwtToken')).toBe(false);
 });
 
-it('should return true', () => {
+it('should return true for many paths of known attrs security and known nested path', () => {
   const operations = [{
     path: {
       post: {
@@ -71,7 +82,7 @@ it('should return true', () => {
   expect(pathMethodsHaveAttr(operations as unknown as Operation[], 'security', 'jwtToken')).toBe(true);
 });
 
-it('should return true', () => {
+it('should return true for a deeply nested path x-nested.required', () => {
   const operations = [{
     path: {
       post: {
@@ -84,4 +95,18 @@ it('should return true', () => {
     },
   }];
   expect(pathMethodsHaveAttr(operations as unknown as Operation[], 'parameters', 'x-nested.required')).toBe(true);
+});
+
+it('should return true for a path attr and an array of nested paths', () => {
+  const operations = [{
+    path: {
+      post: {
+        'security': [{apiKey: ''}],
+      },
+      put: {
+        'security': [{jwtToken: ''}],
+      }
+    },
+  }];
+  expect(pathMethodsHaveAttr(operations as unknown as Operation[], 'security', ['JwtToken', 'jwtToken'])).toBe(true);
 });

--- a/src/lib/template/helpers/pathMethodsHaveAttr.ts
+++ b/src/lib/template/helpers/pathMethodsHaveAttr.ts
@@ -1,38 +1,41 @@
 import * as _ from 'lodash';
-import { Operation, Path } from '@/interfaces';
+import { Operation } from '@/interfaces';
 import isValidMethod from '@/lib/template/helpers/isValidMethod';
 
-type Methods = 'get' |'put' |'post' |'delete' |'options' |'head' |'patch';
+type Methods = 'get' | 'put' | 'post' | 'delete' | 'options' | 'head' | 'patch';
 
-export default (operations: Operation[], attr: string, nestedPath?: string): boolean => {
+export default (operations: Operation[], attr: string, nestedPaths?: string | string[]): boolean => {
+  const nestedPathsToFind: string[] = Array.isArray(nestedPaths) ? nestedPaths : [nestedPaths];
   let found = false;
   for (const key in operations) {
     const op: Operation = operations[key];
     for (const method in op.path) {
       if (isValidMethod(method)) {
         if (op.path[method as Methods][attr as keyof Operation]) {
-          if (!nestedPath) {
+          if (!nestedPaths) {
             found = true;
           } else {
-            const nestedParts = nestedPath.split('.');
-            let objectToLookIn = op.path[method as Methods][attr as keyof Operation];
-            nestedParts.forEach((part) => {
-              if (objectToLookIn) {
-                if (Array.isArray(objectToLookIn)) {
-                  objectToLookIn = objectToLookIn.find(item => {
-                    return item[part] !== undefined;
-                  });
-                  if (objectToLookIn) {
-                    objectToLookIn = objectToLookIn[part];
+            nestedPathsToFind.forEach((nestedPath) => {
+              const nestedParts = nestedPath.split('.');
+              let objectToLookIn = op.path[method as Methods][attr as keyof Operation];
+              nestedParts.forEach((part) => {
+                if (objectToLookIn) {
+                  if (Array.isArray(objectToLookIn)) {
+                    objectToLookIn = objectToLookIn.find(item => {
+                      return item[part] !== undefined;
+                    });
+                    if (objectToLookIn) {
+                      objectToLookIn = objectToLookIn[part];
+                    }
+                  } else {
+                    objectToLookIn = _.get(objectToLookIn, part);
                   }
-                } else {
-                  objectToLookIn = _.get(objectToLookIn, part);
                 }
+              });
+              if (objectToLookIn !== undefined) {
+                found = true;
               }
             });
-            if (objectToLookIn !== undefined) {
-              found = true;
-            }
           }
         }
       }


### PR DESCRIPTION
THIS PR DEPENDS ON AND IS BRANCHED FROM:  https://github.com/acr-lfr/generate-it/pull/173

Boats uppercasing model names by default turns jwtToken into JwtToken when said security def is in its own file.

In the TS server tpl, there is a point that the tpl decides if it should include the jwtaccess or not:
```
{% if pathMethodsHaveAttr(operations, 'security', 'jwtToken') %}import { {{ nodegenRc.helpers.stub.jwtType }} } from '@/http/nodegen/interfaces';{% endif %}
```

In openapi 2, jwtToken stays as jwtToken as it is always declared in the top index.yml

In openapi 3, if you declare it by hand in the index it stays as jwtToken too


In openapi 3, it is common to place security schemas in there own folder under components... when you run an autoIndexer on the security folder and just import all the definitions eg:
components:
```
  schemas:
    $ref: ./components/schemas/index.yml
  parameters:
    $ref: ./components/parameters/index.yml
  securitySchemes:
    $ref: ./components/security/index.yml
```

Then the file, `components/security/jwtToken.yml` ends up being JwtToken in the output of boats (unless you config it to not do that). The result is the above tpl code never injects the JwtAccess token as is it looking for jwtToken and not JwtToken.

This is a pretty hidden combination of events... to bypass this, allowing an array of patterns means the above line can be changed to the following and it will seemlessly work for all cases:

```
{% if pathMethodsHaveAttr(operations, 'security', ['jwtToken', 'JwtToken']) %}import { {{ nodegenRc.helpers.stub.jwtType }} } from '@/http/nodegen/interfaces';{% endif %}
```