### PR TITLE
fix: required fields on nested object was missing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "generate-it",
-  "version": "5.54.0",
+  "version": "5.54.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "generate-it",
-      "version": "5.54.0",
+      "version": "5.54.1",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-it",
-  "version": "5.54.0",
+  "version": "5.54.1",
   "description": "Generate-it, will generate servers, clients, web-socket and anything else you can template with nunjucks from yml files (openapi/asyncapi)",
   "author": "Acrontum GmbH & Liffery Ltd",
   "license": "MIT",

--- a/src/lib/helpers/SwaggerUtils.ts
+++ b/src/lib/helpers/SwaggerUtils.ts
@@ -44,7 +44,7 @@ class SwaggerUtils {
       return;
     }
 
-    const { paramTypeKey } = options;
+    const {paramTypeKey} = options;
     let validationText = param.name ? `'${param.name}'` + ':' : '';
     const isRequired = (options.requiredFields && options.requiredFields.includes(param.name)) || param.required === true;
     const type = param.type || param.schema.type;
@@ -121,6 +121,7 @@ class SwaggerUtils {
             ...properties[propertyKey],
           },
           {
+            requiredFields: Array.isArray(param.required) ? param.required : undefined,
             paramTypeKey,
           }
         );

--- a/src/lib/helpers/__tests__/SwaggerUtils.ts
+++ b/src/lib/helpers/__tests__/SwaggerUtils.ts
@@ -9,9 +9,9 @@ const params = [
       type: 'object',
       required: ['password', 'newPassword'],
       properties: {
-        password: { type: 'string' },
-        newPassword: { type: 'string' },
-        newPasswordConfirm: { type: 'string' },
+        password: {type: 'string'},
+        newPassword: {type: 'string'},
+        newPasswordConfirm: {type: 'string'},
       },
     },
   },
@@ -86,35 +86,35 @@ const params = [
 ];
 
 test('Returns joi with 2 required params', () => {
-  expect(SwaggerUtils.createJoiValidation('post', { parameters: [params[0]] })).toBe(
+  expect(SwaggerUtils.createJoiValidation('post', {parameters: [params[0]]})).toBe(
     `'body': Joi.object({'password':Joi.string().required(),'newPassword':Joi.string().required(),'newPasswordConfirm':Joi.string().allow('').allow(null),}),`
   );
 });
 
 test('openapi3 query request param', () => {
-  expect(SwaggerUtils.createJoiValidation('get', { parameters: [params[1]] })).toBe(`'query': Joi.object({'limit':Joi.number().integer(),}),`);
+  expect(SwaggerUtils.createJoiValidation('get', {parameters: [params[1]]})).toBe(`'query': Joi.object({'limit':Joi.number().integer(),}),`);
 });
 
 test('openapi2 enums', () => {
-  expect(SwaggerUtils.createJoiValidation('get', { parameters: [params[3]] })).toBe(
+  expect(SwaggerUtils.createJoiValidation('get', {parameters: [params[3]]})).toBe(
     `'query': Joi.object({'sort':Joi.string().allow('').valid('asc', 'desc'),}),`
   );
 });
 
 test('openapi3 enums', () => {
-  expect(SwaggerUtils.createJoiValidation('get', { parameters: [params[2]] })).toBe(
+  expect(SwaggerUtils.createJoiValidation('get', {parameters: [params[2]]})).toBe(
     `'query': Joi.object({'sort':Joi.string().allow('').valid('asc', 'desc'),}),`
   );
 });
 
 test('openapi3 query request array param: allow single value', () => {
-  expect(SwaggerUtils.createJoiValidation('get', { parameters: [params[4]] })).toBe(
+  expect(SwaggerUtils.createJoiValidation('get', {parameters: [params[4]]})).toBe(
     `'query': Joi.object({'select':Joi.array().items(Joi.string().allow('')).single(),}),`
   );
 });
 
 test('openapi3 request body: allow empty array', () => {
-  expect(SwaggerUtils.createJoiValidation('get', { parameters: [params[5]] })).toBe(
+  expect(SwaggerUtils.createJoiValidation('get', {parameters: [params[5]]})).toBe(
     `'body': Joi.object({'selected':Joi.array().items(Joi.string().allow('').allow(null)).required(),}),`
   );
 });
@@ -159,7 +159,7 @@ test('add unknown true for headers', () => {
 });
 
 test('query item key is properly created inside the query object', () => {
-  expect(SwaggerUtils.createJoiValidation('get', { parameters: [params[6]] })).toBe(
+  expect(SwaggerUtils.createJoiValidation('get', {parameters: [params[6]]})).toBe(
     `'query': Joi.object({'objectInsideQuery': Joi.object({'prop1':Joi.string().allow(''),}),}),`
   );
 });
@@ -169,28 +169,28 @@ test('query numeric with min / max zero properly adds validation', () => {
     in: 'query',
     name: 'limit',
     required: false,
-    schema: { type: 'number', minimum: 0 },
+    schema: {type: 'number', minimum: 0},
     description: 'Max number of results returned',
     type: 'number',
     minimum: 0,
   };
 
-  expect(SwaggerUtils.createJoiValidation('get', { parameters: [param] })).toBe("'query': Joi.object({'limit':Joi.number().min(0),}),");
+  expect(SwaggerUtils.createJoiValidation('get', {parameters: [param]})).toBe('\'query\': Joi.object({\'limit\':Joi.number().min(0),}),');
 
   param.type = 'integer';
   param.schema.type = 'integer';
-  expect(SwaggerUtils.createJoiValidation('get', { parameters: [param] })).toBe("'query': Joi.object({'limit':Joi.number().integer().min(0),}),");
+  expect(SwaggerUtils.createJoiValidation('get', {parameters: [param]})).toBe('\'query\': Joi.object({\'limit\':Joi.number().integer().min(0),}),');
 
   param.type = 'number';
   param.schema.type = 'number';
   param.schema.maximum = 0;
   param.maximum = 0;
-  expect(SwaggerUtils.createJoiValidation('get', { parameters: [param] })).toBe("'query': Joi.object({'limit':Joi.number().min(0).max(0),}),");
+  expect(SwaggerUtils.createJoiValidation('get', {parameters: [param]})).toBe('\'query\': Joi.object({\'limit\':Joi.number().min(0).max(0),}),');
 
   param.type = 'integer';
   param.schema.type = 'integer';
-  expect(SwaggerUtils.createJoiValidation('get', { parameters: [param] })).toBe(
-    "'query': Joi.object({'limit':Joi.number().integer().min(0).max(0),}),"
+  expect(SwaggerUtils.createJoiValidation('get', {parameters: [param]})).toBe(
+    '\'query\': Joi.object({\'limit\':Joi.number().integer().min(0).max(0),}),'
   );
 });
 
@@ -199,18 +199,18 @@ test('query string with min / max zero properly adds validation', () => {
     in: 'query',
     name: 'limit',
     required: false,
-    schema: { type: 'string', minimum: 0 },
+    schema: {type: 'string', minimum: 0},
     description: 'Max number of results returned',
     type: 'number',
     minimum: 0,
   };
 
-  expect(SwaggerUtils.createJoiValidation('get', { parameters: [param] })).toBe("'query': Joi.object({'limit':Joi.string().allow('').min(0),}),");
+  expect(SwaggerUtils.createJoiValidation('get', {parameters: [param]})).toBe('\'query\': Joi.object({\'limit\':Joi.string().allow(\'\').min(0),}),');
 
   param.schema.maximum = 0;
   param.maximum = 0;
-  expect(SwaggerUtils.createJoiValidation('get', { parameters: [param] })).toBe(
-    "'query': Joi.object({'limit':Joi.string().allow('').min(0).max(0),}),"
+  expect(SwaggerUtils.createJoiValidation('get', {parameters: [param]})).toBe(
+    '\'query\': Joi.object({\'limit\':Joi.string().allow(\'\').min(0).max(0),}),'
   );
 });
 
@@ -253,7 +253,113 @@ test('respects x-nullable and nullable for required body parameters', () => {
     },
   };
 
-  expect(SwaggerUtils.createJoiValidation('get', { parameters: [param] })).toBe(
+  expect(SwaggerUtils.createJoiValidation('get', {parameters: [param]})).toBe(
     `'body': Joi.object({'email':Joi.string().required(),'phoneNumber':Joi.string().allow('').allow(null).required(),'comment':Joi.string().allow('').allow(null).required(),'info':Joi.string().min(10).allow(null).required(),'code':Joi.number().allow(null).required(),}),`
   );
+});
+
+test('post object with nested objects that are required should be required in the joi validation output', () => {
+  const pathObj: any = {
+    'summary': 'Create a teams',
+    'requestBody': {
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              team: {
+                type: 'object',
+                required: ['name', 'isPremium'],
+                properties: {
+                  name: {type: 'string', minLength: 1},
+                  isPremium: {type: 'boolean'},
+                },
+              },
+              invitations: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  required: ['roleId'],
+                  properties: {
+                    id: {type: 'number'},
+                    name: {type: 'string'},
+                    email: {type: 'string'},
+                    roleId: {type: 'number'},
+                    invitationLink: {type: 'string'},
+                    action: {
+                      type: 'string',
+                      enum: ['create', 'update', 'delete'],
+                    },
+                  },
+                },
+              },
+              invitationsLanguage: {type: 'string'},
+            },
+          },
+        },
+      },
+    },
+    'responses': {
+      '200': {
+        description: 'OK',
+        content: {
+          'text/plain': {schema: {type: 'string', example: 'OK'}},
+        },
+      },
+      '400': {description: 'Bad Request'},
+      '401': {description: 'Unauthorized'},
+      '403': {description: 'Forbidden'},
+      '406': {description: 'Not Acceptable'},
+    },
+    'tags': ['Teams'],
+    'operationId': 'teamsPost',
+    'x-passRequest': true,
+    'security': [{JwtToken: []}],
+    'parameters': [
+      {
+        in: 'body',
+        name: 'teamsPostPost',
+        required: true,
+        schema: {
+          type: 'object',
+          properties: {
+            team: {
+              type: 'object',
+              required: ['name', 'isPremium'],
+              properties: {
+                name: {type: 'string', minLength: 1},
+                isPremium: {type: 'boolean'},
+              },
+            },
+            invitations: {
+              type: 'array',
+              items: {
+                type: 'object',
+                required: ['roleId'],
+                properties: {
+                  id: {type: 'number'},
+                  name: {type: 'string'},
+                  email: {type: 'string'},
+                  roleId: {type: 'number'},
+                  invitationLink: {type: 'string'},
+                  action: {
+                    type: 'string',
+                    enum: ['create', 'update', 'delete'],
+                  },
+                },
+              },
+            },
+            invitationsLanguage: {type: 'string'},
+          },
+        },
+      },
+    ]
+  };
+
+  const joiString = SwaggerUtils.createJoiValidation('post', pathObj);
+
+  const expectedouput = `'body': Joi.object({'team':Joi.object({'name':Joi.string().min(1).required(),'isPremium':Joi.boolean().required(),}).allow(null),'invitations':Joi.array().items(Joi.object({'id':Joi.number().allow(null),'name':Joi.string().allow('').allow(null),'email':Joi.string().allow('').allow(null),'roleId':Joi.number().required(),'invitationLink':Joi.string().allow('').allow(null),'action':Joi.string().allow('').valid('create', 'update', 'delete').allow(null),}).allow(null)),'invitationsLanguage':Joi.string().allow('').allow(null),}),`;
+
+  expect(joiString).toBe(expectedouput);
 });


### PR DESCRIPTION
For objects with nested objects that are required... the required fields were not being passed in.

There was simply a line missing, added. Unit test added.

What was happening before was...
```
      {
        in: 'body',
        name: 'teamsPostPost',
        required: true,
        schema: {
          type: 'object',
          properties: {
            team: {
              type: 'object',
              required: ['name', 'isPremium'],
              properties: {
                name: {type: 'string', minLength: 1},
                isPremium: {type: 'boolean'},
              },
            },
            invitations: {
              type: 'array',
              items: {
                type: 'object',
                required: ['roleId'],
                properties: {
                  id: {type: 'number'},
                  name: {type: 'string'},
                  email: {type: 'string'},
                  roleId: {type: 'number'},
                  invitationLink: {type: 'string'},
                  action: {
                    type: 'string',
                    enum: ['create', 'update', 'delete'],
                  },
                },
              },
            },
            invitationsLanguage: {type: 'string'},
          },
        },
      },
```

Resulted in a Joi output of:
```
{
    body: Joi.object({
      team: Joi.object({
        name: Joi.string().min(1).allow(null),
        isPremium: Joi.boolean().allow(null),
      }).allow(null),
      invitations: Joi.array().items(
        Joi.object({
          id: Joi.number().allow(null),
          name: Joi.string().allow('').allow(null),
          email: Joi.string().allow('').allow(null),
          roleId: Joi.number().allow(null),
          invitationLink: Joi.string().allow('').allow(null),
          action: Joi.string()
            .allow('')
            .valid('create', 'update', 'delete')
            .allow(null),
        }).allow(null)
      ),
      invitationsLanguage: Joi.string().allow('').allow(null),
    }),
  },
```

It should have been:
```
    'body': Joi.object({
      'team': Joi.object({
        'name': Joi.string().min(1).required(),  // <<< note the required fields here!! 
        'isPremium': Joi.boolean().required(),
      }).allow(null),
      'invitations': Joi.array().items(Joi.object({
        'id': Joi.number().allow(null),
        'name': Joi.string().allow('').allow(null),
        'email': Joi.string().allow('').allow(null),
        'roleId': Joi.number().required(),
        'invitationLink': Joi.string().allow('').allow(null),
        'action': Joi.string().allow('').valid('create', 'update', 'delete').allow(null),
      }).allow(null)),
      'invitationsLanguage': Joi.string().allow('').allow(null),
    }),
```

This was somehow missing all this time and never reported.
