### PR TITLE
fix: enums and test for type number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 5.56.0 12/08/2024
+feat: Now allows enums on type number and integer
+
 ### 5.55.0 17/01/2024
 feat: Input validation and transformation via `x-joi-<method name>` in a openapi schema. Docs [Joi methods exposed](https://acr-lfr.github.io/generate-it/#/_pages/template-functions?id=joi-validation-amp-transformation)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "generate-it",
-  "version": "5.55.1",
+  "version": "5.56.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "generate-it",
-      "version": "5.55.1",
+      "version": "5.56.0",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-it",
-  "version": "5.55.1",
+  "version": "5.56.0",
   "description": "Generate-it, will generate servers, clients, web-socket and anything else you can template with nunjucks from yml files (openapi/asyncapi)",
   "author": "Acrontum GmbH & Liffery Ltd",
   "license": "MIT",

--- a/src/lib/helpers/SwaggerUtils.ts
+++ b/src/lib/helpers/SwaggerUtils.ts
@@ -91,7 +91,8 @@ class SwaggerUtils {
 
       if (param.enum || (param.schema && param.schema.enum)) {
         const enumValues = param.enum || param.schema.enum;
-        validationText += '.valid(' + enumValues.map((e: string) => `'${e}'`).join(', ') + ')';
+        const validTplString = enumValues.map((e: string) => ['number', 'integer'].includes(type) ? e : `'${e}'`).join(', ');
+        validationText += '.valid(' + validTplString + ')';
       }
 
       if (!Number.isNaN(Number(param.minLength))) {

--- a/src/lib/helpers/__tests__/SwaggerUtils.ts
+++ b/src/lib/helpers/__tests__/SwaggerUtils.ts
@@ -165,6 +165,26 @@ test('query item key is properly created inside the query object', () => {
   );
 });
 
+test('enum values with string and number', () => {
+  const param: Record<string, any> = {
+    in: 'query',
+    name: 'limit',
+    schema: {type: 'number', default: 25, enum: [5, 25, 50]},
+  };
+
+  expect(SwaggerUtils.createJoiValidation('get', {parameters: [param]}, {} as NodegenRc))
+    .toBe('\'query\': Joi.object({\'limit\':Joi.number().default(25).valid(5, 25, 50),}),');
+
+  const paramsString: Record<string, any> = {
+    in: 'query',
+    name: 'limit',
+    schema: {type: 'string', default: '25', enum: ['5', '25', '50']},
+  };
+
+  expect(SwaggerUtils.createJoiValidation('get', {parameters: [paramsString]}, {} as NodegenRc))
+    .toBe('\'query\': Joi.object({\'limit\':Joi.string().allow(\'\').default(\'25\').valid(\'5\', \'25\', \'50\'),}),');
+});
+
 test('query numeric with min / max zero properly adds validation', () => {
   const param: Record<string, any> = {
     in: 'query',


### PR DESCRIPTION
Previously this was blindly setting all valid joi params to strings which fails for input of type number or integer

