### PR TITLE
feat/fix: output joi any

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 5.60.0 23/01/2024
+feat: when the body is `type: object` without props the Joi validation will now be Joi.any() - essentially no validation and anything send use case for example being incoming webhooks from 3rd party with unknown payload. 
+
 ### 5.59.0 12/01/2024
 revert: 5.57.0 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "generate-it",
-  "version": "5.59.0",
+  "version": "5.60.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "generate-it",
-      "version": "5.59.0",
+      "version": "5.60.0",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-it",
-  "version": "5.59.0",
+  "version": "5.60.0",
   "description": "Generate-it, will generate servers, clients, web-socket and anything else you can template with nunjucks from yml files (openapi/asyncapi)",
   "author": "Acrontum GmbH & Liffery Ltd",
   "license": "MIT",

--- a/src/lib/helpers/SwaggerUtils.ts
+++ b/src/lib/helpers/SwaggerUtils.ts
@@ -204,7 +204,14 @@ class SwaggerUtils {
       }
       validationText += `'${paramTypeKey}': Joi.object({`;
       paramsTypes[paramTypeKey].forEach((param: any) => {
-        if (param.schema && param.schema.properties) {
+
+        if (param.schema && param.schema.type === 'object' && !param.schema.properties) {
+          // An object without properties = any = no validation
+          validationText = validationText.replace(
+            `'${paramTypeKey}': Joi.object({`,
+            `'${paramTypeKey}': Joi.any({`
+          );
+        } else if (param.schema && param.schema.properties) {
           if (paramTypeKey === 'query') {
             validationText += `'${param.name}': Joi.object({`;
           }
@@ -234,6 +241,11 @@ class SwaggerUtils {
         }
       });
       validationText += '})';
+
+      // due to string concat pattern in this function replace needed for the joi any
+      validationText = validationText.replace('Joi.any({})', 'Joi.any()');
+
+      // Add unknown to the header validation
       if (paramTypeKey === ParamTypeKey.headers) {
         validationText += '.unknown(true)';
       }

--- a/src/lib/helpers/__tests__/SwaggerUtils.ts
+++ b/src/lib/helpers/__tests__/SwaggerUtils.ts
@@ -84,6 +84,14 @@ const params = [
       ],
     },
   },
+  {
+    in: 'body',
+    name: 'v1UserPasswordAnyPut',
+    required: true,
+    schema: {
+      type: 'object'
+    },
+  },
 ];
 
 test('Returns joi with 2 required params', () => {
@@ -117,6 +125,12 @@ test('openapi3 query request array param: allow single value', () => {
 test('openapi3 request body: allow empty array', () => {
   expect(SwaggerUtils.createJoiValidation('get', {parameters: [params[5]]}, {} as NodegenRc)).toBe(
     `'body': Joi.object({'selected':Joi.array().items(Joi.string().allow('').allow(null)).required(),}),`
+  );
+});
+
+test('openapi3 request body empty object as any', () => {
+  expect(SwaggerUtils.createJoiValidation('put', {parameters: [params[7]]}, {} as NodegenRc)).toBe(
+    `'body': Joi.any(),`
   );
 });
 


### PR DESCRIPTION
When the body is defined as 
```
{
    in: 'body',
    name: 'v1UserPasswordAnyPut',
    required: true,
    schema: {
      type: 'object'
    },
  }
```
output joi any:
```
'body': Joi.any(),
```

currently it breaks and injects the body object name as a param, which is complete wrong.

new test case added and existing tests on the joi output all still pass